### PR TITLE
Set ProjectDeploymentTargetTrigger

### DIFF
--- a/integration/project_trigger_test.go
+++ b/integration/project_trigger_test.go
@@ -12,7 +12,6 @@ func init() {
 	client = initTest()
 }
 
-
 func TestProjectTriggerAddGetAndDelete(t *testing.T) {
 	// need a project to add a trigger to
 	project := createTestProject(t, getRandomName())
@@ -107,7 +106,7 @@ func createTestProjectTrigger(t *testing.T, trigger *octopusdeploy.ProjectTrigge
 }
 
 func getTestProjectTrigger(projectID string) *octopusdeploy.ProjectTrigger {
-	return octopusdeploy.NewProjectTrigger(getRandomName(), projectID, false, []string{"Role1", "Role2"}, []string{"Machine"}, []string{"MachineCleanupFailed"})
+	return octopusdeploy.NewProjectDeploymentTargetTrigger(getRandomName(), projectID, false, []string{"Role1", "Role2"}, []string{"Machine"}, []string{"MachineCleanupFailed"})
 }
 
 func cleanProjectTrigger(t *testing.T, projectTriggerID string) {

--- a/octopusdeploy/project_triggers.go
+++ b/octopusdeploy/project_triggers.go
@@ -63,7 +63,7 @@ func (t *ProjectTrigger) AddEventCategories(eventCategories []string) {
 	}
 }
 
-func NewProjectTrigger(name, projectID string, shouldRedeploy bool, roles, eventGroups, eventCategories []string) *ProjectTrigger {
+func NewProjectDeploymentTargetTrigger(name, projectID string, shouldRedeploy bool, roles, eventGroups, eventCategories []string) *ProjectTrigger {
 	return &ProjectTrigger{
 		Action: ProjectTriggerAction{
 			ActionType: "AutoDeploy",


### PR DESCRIPTION
The `NewProjectDeploymentTargetTrigger` initialization function only creates ProjectDeployment Triggers, not scheduled triggers.