### PR TITLE
Adding variable support

### DIFF
--- a/integration/test_helpers.go
+++ b/integration/test_helpers.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
 	"github.com/satori/go.uuid"
@@ -34,4 +35,8 @@ func getRandomName() string {
 	fullName := fmt.Sprintf("go-octopusdeploy %s", uuid.NewV4())
 	fullName = fullName[0:49] //Some names in Octopus have a max limit of 50 characters (such as Environment Name)
 	return fullName
+}
+
+func getRandomVarName() string {
+	return fmt.Sprintf("go-octo-%v", time.Now().Unix())
 }

--- a/integration/variables_test.go
+++ b/integration/variables_test.go
@@ -1,0 +1,70 @@
+package integration
+
+import (
+	"testing"
+
+	"github.com/MattHodge/go-octopusdeploy/octopusdeploy"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	client = initTest()
+}
+
+func TestVarAddAndDelete(t *testing.T) {
+	varProj := createVarTestProject(t, getRandomName())
+	defer cleanProject(t, varProj.ID)
+	varName := getRandomVarName()
+	expected := getTestVariable(varName)
+	actual := createTestVariable(t, varProj.ID, varName)
+	defer cleanVar(t, actual.ID, varProj.ID)
+
+	assert.Equal(t, expected.Name, actual.Name, "variable name doesn't match expected")
+	assert.NotEmpty(t, actual.ID, "variable doesn't contain an ID from the octopus server")
+}
+
+func createTestVariable(t *testing.T, projectID, variableName string) octopusdeploy.Variable {
+	v := getTestVariable(variableName)
+	variableSet, err := client.Variable.AddSingle(projectID, &v)
+	if err != nil {
+		t.Fatalf("creating variable %s failed when it shouldn't: %s", variableName, err)
+	}
+
+	for _, newV := range variableSet.Variables {
+		if newV.Name == variableName {
+			return newV
+		}
+	}
+
+	t.Fatalf("Unable to locate variable named %s after creationg", variableName)
+	return octopusdeploy.Variable{} //Blank variable to return
+}
+
+func getTestVariable(variableName string) octopusdeploy.Variable {
+	v := octopusdeploy.NewVariable(variableName, "string", "octo-test value", "octo-test description", nil, false)
+
+	return *v
+}
+
+func createVarTestProject(t *testing.T, projectName string) octopusdeploy.Project {
+	p := octopusdeploy.NewProject(projectName, "Lifecycles-1", "ProjectGroups-1")
+	createdProject, err := client.Project.Add(p)
+
+	if err != nil {
+		t.Fatalf("creating project %s failed when it shouldn't: %s", projectName, err)
+	}
+
+	return *createdProject
+}
+func cleanVar(t *testing.T, varID string, projID string) {
+	_, err := client.Variable.DeleteSingle(projID, varID)
+	if err == nil {
+		return
+	}
+	if err == octopusdeploy.ErrItemNotFound {
+		return
+	}
+	if err != nil {
+		t.Fatalf("deleting variable failed when it shouldn't. manual cleanup may be needed. (%s)", err.Error())
+	}
+}

--- a/octopusdeploy/octopusdeploy.go
+++ b/octopusdeploy/octopusdeploy.go
@@ -18,6 +18,7 @@ type Client struct {
 	Project           *ProjectService
 	ProjectTrigger    *ProjectTriggerService
 	Environment       *EnvironmentService
+	Variable          *VariableService
 }
 
 // NewClient returns a new Client.
@@ -33,6 +34,7 @@ func NewClient(httpClient *http.Client, octopusURL, octopusAPIKey string) *Clien
 		Project:           NewProjectService(base.New()),
 		ProjectTrigger:    NewProjectTriggerService(base.New()),
 		Environment:       NewEnvironmentService(base.New()),
+		Variable:          NewVariableService(base.New()),
 	}
 }
 
@@ -111,7 +113,6 @@ func apiAdd(sling *sling.Sling, inputStruct, returnStruct interface{}, path stri
 // Generic OctopusDeploy API Add Function.
 func apiUpdate(sling *sling.Sling, inputStruct, returnStruct interface{}, path string) (interface{}, error) {
 	octopusDeployError := new(APIError)
-
 	resp, err := sling.New().Put(path).BodyJSON(inputStruct).Receive(returnStruct, &octopusDeployError)
 
 	apiErrorCheck := APIErrorChecker(path, resp, http.StatusOK, err, octopusDeployError)

--- a/octopusdeploy/variables.go
+++ b/octopusdeploy/variables.go
@@ -31,7 +31,7 @@ type Variable struct {
 	Name        string                `json:"Name"`
 	Value       string                `json:"Value"`
 	Description string                `json:"Description"`
-	Scope       *VariableScope        `json:"Scope"`
+	Scope       *VariableScope        `json:"Scope,omitempty"`
 	IsEditable  bool                  `json:"IsEditable"`
 	Prompt      VariablePromptOptions `json:"Prompt"`
 	Type        string                `json:"Type"`

--- a/octopusdeploy/variables.go
+++ b/octopusdeploy/variables.go
@@ -1,0 +1,310 @@
+package octopusdeploy
+
+import (
+	"fmt"
+
+	"github.com/dghubble/sling"
+	"gopkg.in/go-playground/validator.v9"
+)
+
+type VariableService struct {
+	sling *sling.Sling
+}
+
+func NewVariableService(sling *sling.Sling) *VariableService {
+	return &VariableService{
+		sling: sling,
+	}
+}
+
+type Variables struct {
+	ID          string      `json:"Id"`
+	OwnerID     string      `json:"OwnerId"`
+	Version     int         `json:"Version"`
+	Variables   []Variable  `json:"Variables"`
+	ScopeValues ScopeValues `json:"ScopeValues"`
+	Links       map[string]string
+}
+
+type Variable struct {
+	ID          string                `json:"Id"`
+	Name        string                `json:"Name"`
+	Value       string                `json:"Value"`
+	Description string                `json:"Description"`
+	Scope       *VariableScope        `json:"Scope"`
+	IsEditable  bool                  `json:"IsEditable"`
+	Prompt      VariablePromptOptions `json:"Prompt"`
+	Type        string                `json:"Type"`
+	IsSensitive bool                  `json:"IsSensitive"`
+}
+
+type VariableScope struct {
+	Project     []string `json:"Project,omitempty"`
+	Environment []string `json:"Environment,omitempty"`
+	Machine     []string `json:"Machine,omitempty"`
+	Role        []string `json:"Role,omitempty"`
+	TargetRole  []string `json:"TargetRole,omitempty"`
+	Action      []string `json:"Action,omitempty"`
+	User        []string `json:"User,omitempty"`
+	Private     []string `json:"Private,omitempty"`
+	Channel     []string `json:"Channel,omitempty"`
+	TenantTag   []string `json:"TenantTag,omitempty"`
+	Tenant      []string `json:"Tenant,omitempty"`
+}
+
+type VariablePromptOptions struct {
+	Label       string `json:"Label"`
+	Description string `json:"Description"`
+	Required    bool   `json:"Required"`
+}
+
+type ScopeValues struct {
+	Environments []ScopeValue `json:"Environments"`
+	Machines     []ScopeValue `json:"Machines"`
+	Actions      []ScopeValue `json:"Actions"`
+	Roles        []ScopeValue `json:"Roles"`
+	Channels     []ScopeValue `json:"Channels"`
+	TenantTags   []ScopeValue `json:"TenantTags"`
+}
+
+type ScopeValue struct {
+	ID   string `json:"Id"`
+	Name string `json:"Name"`
+}
+
+func (t *Variable) Validate() error {
+	validate := validator.New()
+
+	err := validate.Struct(t)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func NewVariable(name, valuetype, value, description string, scope *VariableScope, sensitive bool) *Variable {
+	return &Variable{
+		Name:        name,
+		Value:       value,
+		Description: description,
+		Type:        valuetype,
+		IsSensitive: sensitive,
+		Scope:       scope,
+	}
+}
+
+// GetAll fetches an entire VariableSet from Octopus Deploy for a given Project ID.
+func (s *VariableService) GetAll(projectid string) (*Variables, error) {
+	if projectid == "" { //Not specifying the Project ID can return thousands of entries consuming hundreds of megs of memory
+		return nil, fmt.Errorf("projectid must be specified")
+	}
+
+	path := fmt.Sprintf("variables/variableset-%s", projectid)
+	resp, err := apiGet(s.sling, new(Variables), path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*Variables), nil
+}
+
+// GetByID fetches a single variable, located by its ID, from Octopus Deploy for a given Project ID.
+func (s *VariableService) GetByID(projectid, variableid string) (*Variable, error) {
+	variables, err := s.GetAll(projectid)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, variable := range variables.Variables {
+		if variable.ID == variableid {
+			return &variable, nil
+		}
+	}
+
+	return nil, nil
+}
+
+// GetByName fetches variables, located by their name, from Octopus Deploy for a given Project ID. As variable
+// names can appear more than once under different scopes, a VariableScope must also be provided, which will
+// be used to locate the appropriate variables.
+func (s *VariableService) GetByName(projectid, variablename string, scope *VariableScope) ([]Variable, error) {
+	variables, err := s.GetAll(projectid)
+	if err != nil {
+		return nil, err
+	}
+
+	var matchedVariables []Variable
+
+	for _, variable := range variables.Variables {
+		if variable.Name == variablename {
+			matchScope, _, err := s.MatchesScope(variable.Scope, scope)
+			if err != nil {
+				return nil, err
+			}
+			if matchScope {
+				matchedVariables = append(matchedVariables, variable)
+			}
+		}
+	}
+
+	return matchedVariables, nil
+}
+
+// AddSingle adds a single variable to a project ID. This automates the act of fetching
+// the variable set, adding a new item to it, and posting back to Octopus
+func (s *VariableService) AddSingle(projectid string, variable *Variable) (*Variables, error) {
+	variables, err := s.GetAll(projectid)
+	if err != nil {
+		return nil, err
+	}
+	variables.Variables = append(variables.Variables, *variable)
+	return s.Update(projectid, variables)
+}
+
+// UpdateSingle adds a single variable to a project ID. This automates the act of fetching
+// the variable set, updating the existing item, and posting back to Octopus
+func (s *VariableService) UpdateSingle(projectid string, variable *Variable) (*Variables, error) {
+	variables, err := s.GetAll(projectid)
+	if err != nil {
+		return nil, err
+	}
+
+	var found bool
+	for i, existingVar := range variables.Variables {
+		if existingVar.ID == variable.ID {
+			variables.Variables[i] = *variable
+			found = true
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("Variable with ID %s was not found in variable set %s for updating", variable.ID, projectid)
+	}
+
+	return s.Update(projectid, variables)
+}
+
+// DeleteSingle removes a single variable from a project ID. This automates the act of fetching
+// the variable set, removing the existing item, and posting back to Octopus
+func (s *VariableService) DeleteSingle(projectid string, variableID string) (*Variables, error) {
+	variables, err := s.GetAll(projectid)
+	if err != nil {
+		return nil, err
+	}
+
+	var found bool
+	for i, existingVar := range variables.Variables {
+		if existingVar.ID == variableID {
+			variables.Variables = append(variables.Variables[:i], variables.Variables[i+1:]...)
+			found = true
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf("Variable with ID %s was not found in variable set %s for removal", variableID, projectid)
+	}
+
+	return s.Update(projectid, variables)
+}
+
+// Update takes an entire variable set and posts the entire set back to Octopus Deploy. There are individual
+// functions like AddSingle and UpdateSingle that can make this process more of a "typical" CRUD Octopus command.
+func (s *VariableService) Update(projectid string, variableSet *Variables) (*Variables, error) {
+	path := fmt.Sprintf("variables/variableset-%s", projectid)
+	resp, err := apiUpdate(s.sling, variableSet, new(Variables), path)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.(*Variables), nil
+}
+
+// MatchesScope compares two different scopes to see if they match. Generally used for comparing the scope of
+// an existing variable against a desired state. Only supports Environment, Role, Machine, Action and Channel
+// for scope options. Returns true if definedScope is nil or all elements are empty. Also returns a VariableScope
+// of all the scopes that were matched
+func (s *VariableService) MatchesScope(variableScope, definedScope *VariableScope) (bool, *VariableScope, error) {
+	var matchedScopes VariableScope
+	var matched bool
+
+	//If the scope supplied is nil then match everything
+	if definedScope == nil {
+		return true, &matchedScopes, nil
+	}
+
+	//Unsupported scopes
+	if len(definedScope.Private) > 0 {
+		return false, nil, fmt.Errorf("Private is not a supported scope for variable matching")
+	}
+	if len(definedScope.Project) > 0 {
+		return false, nil, fmt.Errorf("Project is not a supported scope for variable matching")
+	}
+	if len(definedScope.TargetRole) > 0 {
+		return false, nil, fmt.Errorf("TargetRole is not a supported scope for variable matching")
+	}
+	if len(definedScope.Tenant) > 0 {
+		return false, nil, fmt.Errorf("Tenant is not a supported scope for variable matching")
+	}
+	if len(definedScope.TenantTag) > 0 {
+		return false, nil, fmt.Errorf("TenantTag is not a supported scope for variable matching")
+	}
+	if len(definedScope.User) > 0 {
+		return false, nil, fmt.Errorf("User is not a supported scope for variable matching")
+	}
+
+	//If there is no scope to filter on return all the results
+	if len(definedScope.Environment) > 0 && len(definedScope.Role) > 0 && len(definedScope.Machine) > 0 && len(definedScope.Action) > 0 && len(definedScope.Channel) > 0 {
+		return true, &matchedScopes, nil
+	}
+
+	for _, e1 := range definedScope.Environment {
+		for _, e2 := range variableScope.Environment {
+			if e1 == e2 {
+				matched = true
+				matchedScopes.Environment = append(matchedScopes.Environment, e1)
+			}
+		}
+	}
+
+	for _, r1 := range definedScope.Role {
+		for _, r2 := range variableScope.Role {
+			if r1 == r2 {
+				matched = true
+				matchedScopes.Role = append(matchedScopes.Role, r1)
+			}
+		}
+	}
+
+	for _, m1 := range definedScope.Machine {
+		for _, m2 := range variableScope.Machine {
+			if m1 == m2 {
+				matched = true
+				matchedScopes.Machine = append(matchedScopes.Machine, m1)
+			}
+		}
+	}
+
+	for _, a1 := range definedScope.Action {
+		for _, a2 := range variableScope.Action {
+			if a1 == a2 {
+				matched = true
+				matchedScopes.Action = append(matchedScopes.Action, a1)
+			}
+		}
+	}
+
+	for _, c1 := range definedScope.Channel {
+		for _, c2 := range variableScope.Channel {
+			if c1 == c2 {
+				matched = true
+				matchedScopes.Channel = append(matchedScopes.Channel, c1)
+			}
+		}
+	}
+
+	return matched, &matchedScopes, nil
+}


### PR DESCRIPTION
The way Octopus does its variables is not well documented, and a lot of the forum posts are from 3+ years ago, and Octopus has changed the API since then. So here goes:

- Variables have to be submitted in VariableSets
- These VariableSets have to be the complete list of all variables at that point in time
- You need to submit the VariableSet with the ID number of the VariableSet you modified. This acts as a conflict detector - if the VariableSet ID is not the latest VariableSet ID then your changes are rejected

There are only two variable API endpoints we use:

- `Get`
- `Update`

There are no Add or Delete functions in the API, so I've written helper functions that simulate that functionality:

- `AddSingle`
- `UpdateSingle`
 - `DeleteSingle`

All three of these start by fetching the latest VariableSet for a project, manipulating a single record, then immediately submitting the adjusted RecordSet. This means two API requests per change.

You can bulk load changes by simply calling `GetAll`, manipulating the VariableSet however you want, and then calling `Update` submitting the entire VariableSet.