### PR TITLE
Mimic ErrItemNotFound from normal Sling methods

### DIFF
--- a/octopusdeploy/variables.go
+++ b/octopusdeploy/variables.go
@@ -181,7 +181,7 @@ func (s *VariableService) UpdateSingle(projectid string, variable *Variable) (*V
 	}
 
 	if !found {
-		return nil, fmt.Errorf("Variable with ID %s was not found in variable set %s for updating", variable.ID, projectid)
+		return nil, ErrItemNotFound
 	}
 
 	return s.Update(projectid, variables)
@@ -204,7 +204,7 @@ func (s *VariableService) DeleteSingle(projectid string, variableID string) (*Va
 	}
 
 	if !found {
-		return nil, fmt.Errorf("Variable with ID %s was not found in variable set %s for removal", variableID, projectid)
+		return nil, ErrItemNotFound
 	}
 
 	return s.Update(projectid, variables)

--- a/octopusdeploy/variables.go
+++ b/octopusdeploy/variables.go
@@ -308,3 +308,5 @@ func (s *VariableService) MatchesScope(variableScope, definedScope *VariableScop
 
 	return matched, &matchedScopes, nil
 }
+
+//Noop to get GitHub to re-run unit tests


### PR DESCRIPTION
As we are mimicking the basic 'get' and 'create' functionality of the normal API we should use the standard return error of ErrItemNotFound instead of custom errors for these functions.